### PR TITLE
replace build system poetry -> poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ python = "^3.7"
 pytest = "^5.3.5"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=0.12"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
replace build system to poetry-core
according to https://github.com/python-poetry/poetry-core?tab=readme-ov-file#why-is-this-required